### PR TITLE
Remove dependency on current platform's EOL style.

### DIFF
--- a/src/Parser/Lexer.php
+++ b/src/Parser/Lexer.php
@@ -15,8 +15,6 @@ class Lexer implements LexerInterface
      */
     public function lex($expression)
     {
-        $newLineLength = strlen(PHP_EOL);
-
         $this->currentOffset = 0;
         $this->currentLine = 1;
         $this->currentColumn = 0;
@@ -25,24 +23,19 @@ class Lexer implements LexerInterface
         $this->buffer = '';
 
         $length = strlen($expression);
+        $previousChar = null;
 
         while ($this->currentOffset < $length) {
-
+            $char = $expression[$this->currentOffset];
             $this->currentColumn++;
 
             if (
-                0 === substr_compare(
-                    $expression,
-                    PHP_EOL,
-                    $this->currentOffset - $newLineLength,
-                    $newLineLength
-                )
+                "\n" === $previousChar ||
+                ("\r" === $previousChar && "\n" !== $char)
             ) {
                 $this->currentLine++;
                 $this->currentColumn = 1;
             }
-
-            $char = $expression[$this->currentOffset];
 
             if (self::STATE_SIMPLE_STRING === $this->state) {
                 $this->handleSimpleStringState($char);
@@ -55,6 +48,7 @@ class Lexer implements LexerInterface
             }
 
             $this->currentOffset++;
+            $previousChar = $char;
         }
 
         if (self::STATE_SIMPLE_STRING === $this->state) {

--- a/src/Renderer/TreeRenderer.php
+++ b/src/Renderer/TreeRenderer.php
@@ -19,6 +19,31 @@ use Icecave\Dialekt\AST\VisitorInterface;
 class TreeRenderer implements RendererInterface, VisitorInterface
 {
     /**
+     * Construct a new tree renderer,
+     *
+     * @param string|null $endOfLine The end-of-line string to use.
+     */
+    public function __construct($endOfLine = null)
+    {
+        if (null === $endOfLine) {
+            $endOfLine = "\n";
+        }
+
+        $this->endOfLine = $endOfLine;
+        $this->indentLevel = 0;
+    }
+
+    /**
+     * Get the end-of-line string.
+     *
+     * @return string The end-of-line string.
+     */
+    public function endOfLine()
+    {
+        return $this->endOfLine;
+    }
+
+    /**
      * Render an expression to a string.
      *
      * @param ExpressionInterface $expression The expression to render.
@@ -41,7 +66,7 @@ class TreeRenderer implements RendererInterface, VisitorInterface
      */
     public function visitLogicalAnd(LogicalAnd $node)
     {
-        return 'AND' . PHP_EOL . $this->renderChildren($node);
+        return 'AND' . $this->endOfLine() . $this->renderChildren($node);
     }
 
     /**
@@ -55,7 +80,7 @@ class TreeRenderer implements RendererInterface, VisitorInterface
      */
     public function visitLogicalOr(LogicalOr $node)
     {
-        return 'OR' . PHP_EOL . $this->renderChildren($node);
+        return 'OR' . $this->endOfLine() . $this->renderChildren($node);
     }
 
     /**
@@ -71,7 +96,7 @@ class TreeRenderer implements RendererInterface, VisitorInterface
     {
         $child = $node->child()->accept($this);
 
-        return 'NOT' . PHP_EOL . $this->indent('- ' . $child);
+        return 'NOT' . $this->endOfLine() . $this->indent('- ' . $child);
     }
 
     /**
@@ -99,7 +124,7 @@ class TreeRenderer implements RendererInterface, VisitorInterface
      */
     public function visitPattern(Pattern $node)
     {
-        return 'PATTERN' . PHP_EOL . $this->renderChildren($node);
+        return 'PATTERN' . $this->endOfLine() . $this->renderChildren($node);
     }
 
     /**
@@ -151,7 +176,7 @@ class TreeRenderer implements RendererInterface, VisitorInterface
         foreach ($node->children() as $n) {
             $output .= $this->indent(
                 '- ' . $n->accept($this)
-            ) . PHP_EOL;
+            ) . $this->endOfLine();
         }
 
         return rtrim($output);
@@ -159,8 +184,11 @@ class TreeRenderer implements RendererInterface, VisitorInterface
 
     private function indent($string)
     {
-        return '  ' . str_replace(PHP_EOL, PHP_EOL . '  ', $string);
+        $endOfLine = $this->endOfLine();
+
+        return '  ' . str_replace($endOfLine, $endOfLine . '  ', $string);
     }
 
-    private $indentLevel = 0;
+    private $endOfLine;
+    private $indentLevel;
 }

--- a/test/suite/Parser/LexerTest.php
+++ b/test/suite/Parser/LexerTest.php
@@ -160,17 +160,25 @@ class LexerTest extends PHPUnit_Framework_TestCase
                     new Token(Token::STRING, 'spam', 11, 4, 3, 1),
                 ),
             ),
-            'newline inside string' => array(
-                '"foo'. PHP_EOL . 'bar"',
+            'newline handling' => array(
+                '"foo'. "\n" . 'bar" baz',
                 array(
-                    new Token(
-                        Token::STRING,
-                        'foo' . PHP_EOL . 'bar',
-                        0,
-                        8 + strlen(PHP_EOL),
-                        1,
-                        1
-                    ),
+                    new Token(Token::STRING, 'foo' . "\n" . 'bar', 0, 9, 1, 1),
+                    new Token(Token::STRING, 'baz', 10, 3, 2, 6),
+                ),
+            ),
+            'carriage return handling' => array(
+                '"foo'. "\r" . 'bar" baz',
+                array(
+                    new Token(Token::STRING, 'foo' . "\r" . 'bar', 0, 9, 1, 1),
+                    new Token(Token::STRING, 'baz', 10, 3, 2, 6),
+                ),
+            ),
+            'carriage return + newline handling' => array(
+                '"foo'. "\r\n" . 'bar" baz',
+                array(
+                    new Token(Token::STRING, 'foo' . "\r\n" . 'bar', 0, 10, 1, 1),
+                    new Token(Token::STRING, 'baz', 11, 3, 2, 6),
                 ),
             ),
         );

--- a/test/suite/Renderer/TreeRendererTest.php
+++ b/test/suite/Renderer/TreeRendererTest.php
@@ -16,7 +16,19 @@ class TreeRendererTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        $this->renderer = new TreeRenderer("\r\n");
+    }
+
+    public function testConstructor()
+    {
+        $this->assertSame("\r\n", $this->renderer->endOfLine());
+    }
+
+    public function testConstructorDefaults()
+    {
         $this->renderer = new TreeRenderer;
+
+        $this->assertSame("\n", $this->renderer->endOfLine());
     }
 
     /**
@@ -65,8 +77,8 @@ class TreeRendererTest extends PHPUnit_Framework_TestCase
                     new PatternLiteral('foo'),
                     new PatternWildcard
                 ),
-                'PATTERN' . PHP_EOL .
-                '  - LITERAL "foo"' . PHP_EOL .
+                'PATTERN' . "\r\n" .
+                '  - LITERAL "foo"' . "\r\n" .
                 '  - WILDCARD',
             ),
             'escaped pattern' => array(
@@ -74,8 +86,8 @@ class TreeRendererTest extends PHPUnit_Framework_TestCase
                     new PatternLiteral('foo"'),
                     new PatternWildcard
                 ),
-                'PATTERN' . PHP_EOL .
-                '  - LITERAL "foo\\""' . PHP_EOL .
+                'PATTERN' . "\r\n" .
+                '  - LITERAL "foo\\""' . "\r\n" .
                 '  - WILDCARD',
             ),
             'logical and' => array(
@@ -84,9 +96,9 @@ class TreeRendererTest extends PHPUnit_Framework_TestCase
                     new Tag('b'),
                     new Tag('c')
                 ),
-                'AND' . PHP_EOL .
-                '  - TAG "a"' . PHP_EOL .
-                '  - TAG "b"' . PHP_EOL .
+                'AND' . "\r\n" .
+                '  - TAG "a"' . "\r\n" .
+                '  - TAG "b"' . "\r\n" .
                 '  - TAG "c"',
             ),
             'logical or' => array(
@@ -95,16 +107,16 @@ class TreeRendererTest extends PHPUnit_Framework_TestCase
                     new Tag('b'),
                     new Tag('c')
                 ),
-                'OR' . PHP_EOL .
-                '  - TAG "a"' . PHP_EOL .
-                '  - TAG "b"' . PHP_EOL .
+                'OR' . "\r\n" .
+                '  - TAG "a"' . "\r\n" .
+                '  - TAG "b"' . "\r\n" .
                 '  - TAG "c"',
             ),
             'logical not' => array(
                 new LogicalNot(
                     new Tag('a')
                 ),
-                'NOT' . PHP_EOL .
+                'NOT' . "\r\n" .
                 '  - TAG "a"',
             ),
         );


### PR DESCRIPTION
Lexer behaviour currently changes depending on the host platform, which is undesirable considering it's probably user input, and the EOL style used by the user is beyond our control. This PR:
- Provides support for all standard EOL styles
- Improves the consistency of lexer output
- Allows finer control of EOLs in rendered output
